### PR TITLE
Install browserify dependencies by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,16 @@
     "hashing",
     "perceptual"
   ],
+  "dependencies": {
+    "jpeg-js": "0.0.4",
+    "png-js": "^0.1.1",
+    "browserify-shim": "^3.8.0"
+  },
   "devDependencies": {
-    "browserify-shim": "^3.8.0",
     "expect.js": "*",
     "glob": "*",
-    "jpeg-js": "0.0.4",
     "jshint": "*",
-    "mocha": "*",
-    "png-js": "^0.1.1"
+    "mocha": "*"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
In my application, I include all by browserify dependencies in package.json, and then run a build step to package the javascript into a browser bundle. But browserify fails to compile blockhash as the jpeg-js and png dependency are not found. The reason is that npm by default doesnt install devDependency when used by other modules.